### PR TITLE
add initial sphere script as a cli option

### DIFF
--- a/src/ttmask/sphere.py
+++ b/src/ttmask/sphere.py
@@ -4,8 +4,6 @@ import einops
 import napari
 import typer
 
-typer.main.get_command_name = lambda name: name
-
 @cli.command(name='sphere')
 def sphere(
     boxsize: int = typer.Option(...),


### PR DESCRIPTION
removed the line which enabled underscores in typer options - now will be specified with dashes

ttmask sphere --boxsize 100 --sphere-diameter 30
