### PR TITLE
restructure cli imports

### DIFF
--- a/src/ttmask/__init__.py
+++ b/src/ttmask/__init__.py
@@ -17,4 +17,3 @@ from .cube import cube
 from .cone import cone
 from .ellipsoid import ellipsoid
 
-

--- a/src/ttmask/cone.py
+++ b/src/ttmask/cone.py
@@ -4,6 +4,7 @@ import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
 from ._cli import cli
+from .soft_edge import add_soft_edge
 
 
 @cli.command(name='cone')
@@ -13,7 +14,7 @@ def cone(
     cone_base_diameter: float = typer.Option(...),
     soft_edge_width: int = typer.Option(0),
     pixel_size: float = typer.Option(...),
-    output: str = typer.Option("cone.mrc")
+    output: str = typer.Option("cone.mrc"),
 ):
     c = sidelength // 2
     center = np.array([c, c, c])
@@ -23,7 +24,7 @@ def cone(
     positions = np.indices([sidelength, sidelength, sidelength])
     positions = einops.rearrange(positions, 'zyx d h w -> d h w zyx')
 
-    centered = positions - center  #pixels relative to center point
+    centered = positions - center  # pixels relative to center point
     magnitudes = np.linalg.norm(centered, axis=-1)
 
     magnitudes = einops.rearrange(magnitudes, 'd h w -> d h w 1')
@@ -50,18 +51,12 @@ def cone(
     # mask[within_cone_height] = 1
     mask[np.logical_and(within_cone_height, within_cone_angle)] = 1
 
+    #   need to adjust the center of the hollow cone otherwise the cone thins towards the apex
+    # thickness will need to decrease towards the apex anyway - it's surely not possible / realistic?
+
     # Shift the mask in the z-axis by cone_height / 2
     z_shift = -int(cone_height / 2)
     mask = np.roll(mask, z_shift, axis=0)
+    mask = add_soft_edge(mask, soft_edge_width)
 
-
-    distance_from_edge = distance_transform_edt(mask == 0)
-    boundary_pixels = (distance_from_edge <= soft_edge_width) & (distance_from_edge != 0)
-    normalised_distance_from_edge = (distance_from_edge[boundary_pixels] / soft_edge_width) * np.pi
-
-    mask[boundary_pixels] = (0.5 * np.cos(normalised_distance_from_edge) + 0.5)
-
-
-    mrcfile.write(output, mask, voxel_size= pixel_size, overwrite=True)
-
-
+    mrcfile.write(output, mask, voxel_size=pixel_size, overwrite=True)

--- a/src/ttmask/cone.py
+++ b/src/ttmask/cone.py
@@ -3,6 +3,7 @@ import einops
 import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
+
 from ._cli import cli
 from .soft_edge import add_soft_edge
 

--- a/src/ttmask/cone.py
+++ b/src/ttmask/cone.py
@@ -1,7 +1,6 @@
 import numpy as np
 import einops
 import typer
-from scipy.ndimage import distance_transform_edt
 import mrcfile
 
 from ._cli import cli

--- a/src/ttmask/cube.py
+++ b/src/ttmask/cube.py
@@ -1,7 +1,6 @@
 import numpy as np
 import einops
 import typer
-from scipy.ndimage import distance_transform_edt
 import mrcfile
 from .soft_edge import add_soft_edge
 

--- a/src/ttmask/cube.py
+++ b/src/ttmask/cube.py
@@ -1,10 +1,11 @@
 import numpy as np
 import einops
 import typer
-from ._cli import cli
 from scipy.ndimage import distance_transform_edt
 import mrcfile
 from .soft_edge import add_soft_edge
+
+from ._cli import cli
 
 
 @cli.command(name='cube')

--- a/src/ttmask/cuboid.py
+++ b/src/ttmask/cuboid.py
@@ -3,7 +3,6 @@ import einops
 import typer
 from typing import Tuple
 from typing_extensions import Annotated
-from scipy.ndimage import distance_transform_edt
 import mrcfile
 from .soft_edge import add_soft_edge
 

--- a/src/ttmask/cuboid.py
+++ b/src/ttmask/cuboid.py
@@ -6,6 +6,7 @@ from ._cli import cli
 from typing_extensions import Annotated
 from scipy.ndimage import distance_transform_edt
 import mrcfile
+from .soft_edge import add_soft_edge
 
 
 @cli.command(name='cuboid')
@@ -43,15 +44,12 @@ def cuboid(
     inside_cuboid = np.all(difference < (np.array(cuboid_sidelengths) / (2 * pixel_size)), axis=-1)
 
     mask[inside_cuboid] = 1
-
+       
     if wall_thickness != 0:
         within_hollowing = np.all(difference < ((np.array(cuboid_sidelengths) / (2 * pixel_size)) - wall_thickness), axis=-1)
         mask[within_hollowing] = 0
-
-    distance_from_edge = distance_transform_edt(mask == 0)
-    boundary_pixels = (distance_from_edge <= soft_edge_width) & (distance_from_edge != 0)
-    normalised_distance_from_edge = (distance_from_edge[boundary_pixels] / soft_edge_width) * np.pi
-
-    mask[boundary_pixels] = (0.5 * np.cos(normalised_distance_from_edge) + 0.5)
+  
+    mask = add_soft_edge(mask, soft_edge_width)
 
     mrcfile.write(output, mask, voxel_size= pixel_size, overwrite=True)
+

--- a/src/ttmask/cuboid.py
+++ b/src/ttmask/cuboid.py
@@ -2,11 +2,12 @@ import numpy as np
 import einops
 import typer
 from typing import Tuple
-from ._cli import cli
 from typing_extensions import Annotated
 from scipy.ndimage import distance_transform_edt
 import mrcfile
 from .soft_edge import add_soft_edge
+
+from ._cli import cli
 
 
 @cli.command(name='cuboid')

--- a/src/ttmask/cylinder.py
+++ b/src/ttmask/cylinder.py
@@ -3,6 +3,7 @@ import einops
 import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
+
 from ._cli import cli
 from .soft_edge import add_soft_edge
 

--- a/src/ttmask/cylinder.py
+++ b/src/ttmask/cylinder.py
@@ -1,7 +1,6 @@
 import numpy as np
 import einops
 import typer
-from scipy.ndimage import distance_transform_edt
 import mrcfile
 
 from ._cli import cli

--- a/src/ttmask/cylinder.py
+++ b/src/ttmask/cylinder.py
@@ -4,6 +4,7 @@ import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
 from ._cli import cli
+from .soft_edge import add_soft_edge
 
 
 @cli.command(name='cylinder')
@@ -40,11 +41,6 @@ def cylinder(
         within_xy_hollowing = xy_distance < ((cylinder_radius - wall_thickness) / pixel_size)
         mask[np.logical_and(within_z_hollowing, within_xy_hollowing)] = 0
 
-    distance_from_edge = distance_transform_edt(mask == 0)
-    boundary_pixels = (distance_from_edge <= soft_edge_width) & (distance_from_edge != 0)
-    normalised_distance_from_edge = (distance_from_edge[boundary_pixels] / soft_edge_width) * np.pi
+    mask = add_soft_edge(mask, soft_edge_width)
 
-    mask[boundary_pixels] = (0.5 * np.cos(normalised_distance_from_edge) + 0.5)
-
-    mrcfile.write(output, mask, voxel_size= pixel_size, overwrite=True)
-
+    mrcfile.write(output, mask, voxel_size=pixel_size, overwrite=True)

--- a/src/ttmask/ellipsoid.py
+++ b/src/ttmask/ellipsoid.py
@@ -1,10 +1,11 @@
-from ._cli import cli
 import numpy as np
 import einops
 import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
 from .soft_edge import add_soft_edge
+
+from ._cli import cli
 
 
 @cli.command(name='ellipsoid')

--- a/src/ttmask/ellipsoid.py
+++ b/src/ttmask/ellipsoid.py
@@ -1,7 +1,6 @@
 import numpy as np
 import einops
 import typer
-from scipy.ndimage import distance_transform_edt
 import mrcfile
 from .soft_edge import add_soft_edge
 
@@ -41,10 +40,11 @@ def ellipsoid(
     in_ellipsoid = (((x_magnitude) ** 2) / (x_axis_length ** 2)) + ((y_magnitude ** 2) / (y_axis_length ** 2)) + (
         (z_magnitude ** 2) / (z_axis_length ** 2)) <= 1
     mask[in_ellipsoid] = 1
-    
+
     if wall_thickness != 0:
-        in_hollowing = (((x_magnitude) ** 2) / ((x_axis_length - wall_thickness) ** 2)) + ((y_magnitude ** 2) / ((y_axis_length - wall_thickness) ** 2)) + (
-            (z_magnitude ** 2) / ((z_axis_length - wall_thickness) ** 2)) <= 1
+        in_hollowing = (((x_magnitude) ** 2) / ((x_axis_length - wall_thickness) ** 2)) + (
+                (y_magnitude ** 2) / ((y_axis_length - wall_thickness) ** 2)) + (
+                           (z_magnitude ** 2) / ((z_axis_length - wall_thickness) ** 2)) <= 1
         mask[in_hollowing] = 0
 
     mask = add_soft_edge(mask, soft_edge_width)

--- a/src/ttmask/ellipsoid.py
+++ b/src/ttmask/ellipsoid.py
@@ -4,6 +4,7 @@ import einops
 import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
+from .soft_edge import add_soft_edge
 
 
 @cli.command(name='ellipsoid')
@@ -37,18 +38,14 @@ def ellipsoid(
     x_axis_length = width / (2 * pixel_size)
 
     in_ellipsoid = (((x_magnitude) ** 2) / (x_axis_length ** 2)) + ((y_magnitude ** 2) / (y_axis_length ** 2)) + (
-            (z_magnitude ** 2) / (z_axis_length ** 2)) <= 1
+        (z_magnitude ** 2) / (z_axis_length ** 2)) <= 1
     mask[in_ellipsoid] = 1
-
+    
     if wall_thickness != 0:
         in_hollowing = (((x_magnitude) ** 2) / ((x_axis_length - wall_thickness) ** 2)) + ((y_magnitude ** 2) / ((y_axis_length - wall_thickness) ** 2)) + (
             (z_magnitude ** 2) / ((z_axis_length - wall_thickness) ** 2)) <= 1
         mask[in_hollowing] = 0
 
-    distance_from_edge = distance_transform_edt(mask == 0)
-    boundary_pixels = (distance_from_edge <= soft_edge_width) & (distance_from_edge != 0)
-    normalised_distance_from_edge = (distance_from_edge[boundary_pixels] / soft_edge_width) * np.pi
-
-    mask[boundary_pixels] = (0.5 * np.cos(normalised_distance_from_edge) + 0.5)
+    mask = add_soft_edge(mask, soft_edge_width)
 
     mrcfile.write(output, mask, voxel_size=pixel_size, overwrite=True)

--- a/src/ttmask/soft_edge.py
+++ b/src/ttmask/soft_edge.py
@@ -1,0 +1,11 @@
+import numpy as np
+from scipy.ndimage import distance_transform_edt
+
+
+def add_soft_edge(mask: np.ndarray, width: float) -> np.ndarray:
+    distance_from_edge = distance_transform_edt(mask == 0)
+    boundary_pixels = (distance_from_edge <= width) & (distance_from_edge != 0)
+    normalised_distance_from_edge = (distance_from_edge[boundary_pixels] / width) * np.pi
+    output = np.copy(mask)
+    output[boundary_pixels] = (0.5 * np.cos(normalised_distance_from_edge) + 0.5)
+    return output

--- a/src/ttmask/sphere.py
+++ b/src/ttmask/sphere.py
@@ -1,8 +1,6 @@
-from ._cli import cli
 import numpy as np
 import einops
 import typer
-from scipy.ndimage import distance_transform_edt
 import mrcfile
 
 from .soft_edge import add_soft_edge

--- a/src/ttmask/sphere.py
+++ b/src/ttmask/sphere.py
@@ -4,7 +4,9 @@ import einops
 import typer
 from scipy.ndimage import distance_transform_edt
 import mrcfile
+
 from .soft_edge import add_soft_edge
+from ._cli import cli
 
 
 @cli.command(name='sphere')
@@ -35,11 +37,11 @@ def sphere(
     print('calculating which pixels are in sphere')
     idx = distance < (sphere_radius / pixel_size)
     mask[idx] = 1
-    
+
     if wall_thickness != 0:
         within_hollowing = distance < ((sphere_radius - wall_thickness) / pixel_size)
         mask[within_hollowing] = 0
-        
+
     mask = add_soft_edge(mask, soft_edge_width)
 
     mrcfile.write(output, mask, voxel_size=pixel_size, overwrite=True)


### PR DESCRIPTION
minor formatting thing

> Organize imports into groups: first standard library imports, then third-party imports, and finally local application or library imports.

c.f. https://realpython.com/python-import/#imports-style-guide
