### PR TITLE
Fix ttfsc error from not specifying custom centering

### DIFF
--- a/src/ttmask/box_setup.py
+++ b/src/ttmask/box_setup.py
@@ -2,7 +2,7 @@ import numpy as np
 import einops
 
 
-def box_setup(sidelength: int, centering: str, custom_center: tuple):
+def box_setup(sidelength: int, centering: str = None, custom_center: tuple = None):
     c = sidelength // 2
     if centering == "visual" and sidelength % 2 == 0:
         center = np.array([c, c, c]) - 0.5


### PR DESCRIPTION
Commit f1bddef caused ttfsc to throw an error when calling box_setup.
I've put default values in so centering and custom_center don't need to be provided.
